### PR TITLE
works with 2026.2.21-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "agentmail": "^0.2.6",
-    "zod": "^3.23.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "openclaw": "^2026.1.0",

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk";
+import { normalizeAccountId } from "openclaw/plugin-sdk";
 
 import type {
   AgentMailConfig,
@@ -33,10 +33,11 @@ export function resolveCredentials(
 export function resolveAgentMailAccount(params: {
   cfg: CoreConfig;
   accountId?: string | null;
+  env?: Record<string, string | undefined>;
 }): ResolvedAgentMailAccount {
   const accountId = normalizeAccountId(params.accountId);
   const base = (params.cfg.channels?.agentmail ?? {}) as AgentMailConfig;
-  const { apiKey, inboxId } = resolveCredentials(params.cfg);
+  const { apiKey, inboxId } = resolveCredentials(params.cfg, params.env);
 
   return {
     accountId,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -111,7 +111,8 @@ export const agentmailPlugin: ChannelPlugin<ResolvedAgentMailAccount> = {
     validateInput: ({ input }) => {
       if (input.useEnv) return null;
       if (!input.token?.trim()) return "AgentMail requires --token";
-      if (!input.emailAddress?.trim())
+      const inputAny = input as { emailAddress?: string };
+      if (!inputAny.emailAddress?.trim())
         return "AgentMail requires --email-address";
       return null;
     },
@@ -120,7 +121,8 @@ export const agentmailPlugin: ChannelPlugin<ResolvedAgentMailAccount> = {
       const updates: Record<string, unknown> = { enabled: true };
       if (!input.useEnv) {
         if (input.token?.trim()) updates.token = input.token.trim();
-        if (input.emailAddress?.trim()) updates.emailAddress = input.emailAddress.trim();
+        const inputAny = input as { emailAddress?: string };
+        if (inputAny.emailAddress?.trim()) updates.emailAddress = inputAny.emailAddress.trim();
       }
       return { ...cfg, channels: { ...(cfg as CoreConfig).channels, agentmail: { ...existing, ...updates } } };
     },
@@ -147,7 +149,6 @@ export const agentmailPlugin: ChannelPlugin<ResolvedAgentMailAccount> = {
         })),
     buildChannelSummary: ({ snapshot: s }) => ({
       configured: s.configured ?? false,
-      emailAddress: s.emailAddress ?? null,
       running: s.running ?? false,
       lastStartAt: s.lastStartAt ?? null,
       lastStopAt: s.lastStopAt ?? null,
@@ -186,7 +187,7 @@ export const agentmailPlugin: ChannelPlugin<ResolvedAgentMailAccount> = {
   gateway: {
     startAccount: async (ctx) => {
       const { accountId, inboxId } = ctx.account;
-      ctx.setStatus({ accountId, emailAddress: inboxId });
+      ctx.setStatus({ accountId, configured: true });
       ctx.log?.info(
         `[${accountId}] starting AgentMail provider (email: ${
           inboxId ?? "unknown"

--- a/src/outbound.ts
+++ b/src/outbound.ts
@@ -2,7 +2,6 @@ import type { AgentMailClient } from "agentmail";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk";
 
 import { getClientAndInbox } from "./client.js";
-import { getAgentMailRuntime } from "./runtime.js";
 
 /** Sends a reply-all to an email message via AgentMail. */
 export async function sendAgentMailReply(params: {
@@ -42,7 +41,7 @@ async function sendMessage(params: {
 /** Outbound adapter for the AgentMail channel. */
 export const agentmailOutbound: ChannelOutboundAdapter = {
   // Use batch mode: collect all content, send as single email at the end
-  deliveryMode: "batch",
+  deliveryMode: "direct",
   
   // No chunking for email - send complete response as one message
   // Email has no practical length limit like chat messages do


### PR DESCRIPTION
Fixes #2. Tested to be working with OpenClaw 2026-2.21-2

1. Zod upgrade: Updated from v3 to v4 ("zod": "^4.3.6") - fixes toJSONSchema error
2. Outbound deliveryMode: Changed "batch" to "direct" (valid options: "direct", "gateway", "hybrid")
3. WebSocket connect: Changed authToken to apiKey (SDK API change)
4. Attachment download: Updated to use new API - getAttachment now returns an object with downloadUrl instead of file content directly
5. ChatType: Changed "dm" to "direct" (valid types: "direct", "group", "channel")
6. Channel types: Used type assertions for fields removed from SDK types (emailAddress in setup/status)